### PR TITLE
docs: fix license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Flask-WebpackExt is free software; you can redistribute it and/or modify it
 under the terms of the Revised BSD License quoted below.
 
-Copyright (C) 2017 CERN.
+Copyright (C) 2017-2018 CERN.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -30,7 +30,3 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
-
-In applying this license, CERN does not waive the privileges and immunities
-granted to it by virtue of its status as an Intergovernmental Organization or
-submit itself to any jurisdiction.

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -2,3 +2,9 @@ License
 =======
 
 .. include:: ../LICENSE
+
+.. note::
+
+    In applying this license, CERN does not waive the privileges and immunities
+    granted to it by virtue of its status as an Intergovernmental Organization
+    or submit itself to any jurisdiction.


### PR DESCRIPTION
* Moves CERN license disclaimer from LICENSE file to documentation.